### PR TITLE
Added Batching extraction strategy

### DIFF
--- a/recall/constants.py
+++ b/recall/constants.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+class ExtractionStrategy(Enum):
+    ALWAYS = "always"
+    BATCH = "batch"
+    HEURISTIC = "heuristic"
+
+    @staticmethod
+    def from_str(label: str) -> "ExtractionStrategy":
+        label = label.lower()
+        for strategy in ExtractionStrategy:
+            if strategy.value == label:
+                return strategy
+        raise ValueError(f"Unknown strategy: {label}")

--- a/recall/extraction/strategies.py
+++ b/recall/extraction/strategies.py
@@ -1,0 +1,24 @@
+from collections import defaultdict
+from recall.llm.extractor import extract_memories_from_input
+
+_batch_cache = defaultdict(list)
+
+def extract_from_batch(user_id, message, store, llm_call, metadata=None):
+    batch_size = metadata.get("batch_size", 5) if metadata else 5
+
+    _batch_cache[user_id].append(message)
+
+    if len(_batch_cache[user_id]) < batch_size:
+        return [] 
+
+    # Concatenate batch for extraction
+    combined_input = "\n".join(_batch_cache[user_id])
+    extracted = extract_memories_from_input(combined_input, llm_call)
+
+    # Reset batch
+    _batch_cache[user_id] = []
+
+    return extracted
+def is_memory_worthy(text: str) -> bool:
+    # TODO: Implement a more sophisticated heuristic
+    return len(text) > 25 or any(word in text.lower() for word in ["i", "my", "remember"])

--- a/recall/handlers/user_message_handler.py
+++ b/recall/handlers/user_message_handler.py
@@ -1,15 +1,39 @@
 from ..memory.memory_entry import MemoryEntry
 from ..memory.memory_store import MemoryStore
 from ..llm.extractor import extract_memories_from_input
+from ..extraction.strategies import ExtractionStrategy
 
-# Then pass it into extract_memories_from_input()
-
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 import json
 
 
-def handle_user_message(user_id: str, message: str, store: MemoryStore, llm_call: Callable[[str], str]):
-    extracted_memories = extract_memories_from_input(message, llm_call)
+def handle_user_message(
+    user_id: str,
+    message: str,
+    store: MemoryStore,
+    llm_call: Callable[[str], str],
+    extraction_strategy: ExtractionStrategy = ExtractionStrategy.ALWAYS,
+    metadata: Optional[dict] = None
+):
+    if isinstance(extraction_strategy, str):
+        extraction_strategy = ExtractionStrategy.from_str(extraction_strategy)
+
+    if extraction_strategy == ExtractionStrategy.ALWAYS:
+        extracted_memories = extract_memories_from_input(message, llm_call)
+
+    elif extraction_strategy == ExtractionStrategy.BATCH:
+        from ..extraction.strategies import extract_from_batch
+        extracted_memories = extract_from_batch(user_id, message, store, llm_call, metadata)
+
+    elif extraction_strategy == ExtractionStrategy.HEURISTIC:
+        from ..extraction.strategies import is_memory_worthy
+        if is_memory_worthy(message):
+            extracted_memories = extract_memories_from_input(message, llm_call)
+        else:
+            extracted_memories = []
+
+    else:
+        raise ValueError(f"Unsupported extraction strategy: {extraction_strategy}")
 
     for mem in extracted_memories:
         entry = MemoryEntry(


### PR DESCRIPTION
The existing extraction strategy sends an LLM API call for every message. 

Added a new extraction strategy called batching. This enables user to batch and send queries to LLMs for building memory and reduces number of API calls. The batch_size is also configurable. Ex:

```python
handle_user_message(
    user_id="abc",
    message="I just got a puppy!",
    store=store,
    llm_call=llm_call,
    extraction_strategy="batch",
    metadata={"batch_size": 3}
)

```

If user still wants to use the 'always' strategy,


```python
handle_user_message(
    user_id="abc",
    message="I just got a puppy!",
    store=store,
    llm_call=llm_call,
    extraction_strategy="always",
    
)

```


