### PR TITLE
Added export and import features for memories

### DIFF
--- a/recall/memory/memory_entry.py
+++ b/recall/memory/memory_entry.py
@@ -37,16 +37,16 @@ class MemoryEntry:
         }
 
     @staticmethod
-    def from_dict(data: dict) -> 'MemoryEntry':
+    def from_dict(data: dict) -> "MemoryEntry":
         return MemoryEntry(
-            id=data.get("id", str(uuid.uuid4())),
+            id=data["id"],
             user_id=data["user_id"],
             content=data["content"],
             created_at=datetime.fromisoformat(data["created_at"]),
-            last_accessed=datetime.fromisoformat(data["last_accessed"]),
+            last_accessed=datetime.fromisoformat(data.get("last_accessed", data["created_at"])),
             tags=data.get("tags", []),
             importance=data.get("importance", 0.5),
             ttl_days=data.get("ttl_days", 365),
-            source=data.get("source", "unknown"),
+            source=data.get("source", "import"),
             embedding=data.get("embedding"),
         )


### PR DESCRIPTION
# Memory Export & Import

Recall now supports exporting and importing memory entries as JSON.



##  Export Memories

Export all memories for a specific user to a file or as a Python list of dictionaries.

### Export to file:
```python
from recall.memory.memory_store import MemoryStore

store = MemoryStore()  

store.export_memories(user_id="user1", path="backup.json")
```

###  Export as a Python list:
```python
memories = store.export_memories(user_id="user1")
```



## Import Memories

Import memory entries from a previously saved JSON structure.

```python
with open("backup.json") as f:
    data = json.load(f)
    store.import_memories(data)
```

- Validates required fields
- Skips malformed entries
- Automatically handles timestamps and embeddings

---

## Clear Store Functionality

Export → Clear → Re-import:

```python
data = store.export_memories("user1")
store.clear_user_memories("user1")
store.import_memories(data)
```

---

##  Notes
- This feature works independently of the backend (SQLite for now, Redis coming soon).
- All serialization is handled through `MemoryEntry.to_dict()` and `.from_dict()`.

